### PR TITLE
FIX : Sentry API, Store endpoint needs the 'project_id'

### DIFF
--- a/src/core/modules/syslog/mod_syslog_sentry.php
+++ b/src/core/modules/syslog/mod_syslog_sentry.php
@@ -396,7 +396,7 @@ class mod_syslog_sentry extends LogHandler implements LogHandlerInterface {
 		if (empty($options['tags']['engine']))
 			$options['tags']['engine'] = 'Dolibarr '.DOL_VERSION;
 
-		$this->_serverUrl = sprintf('%s://%s%s/api/store/', $scheme, $netloc, $path);
+		$this->_serverUrl = sprintf('%s://%s%s/api/%s/store/', $scheme, $netloc, $path, $project);
 		$this->_secretKey = (string) $password;
 		$this->_publicKey = (string) $username;
 		$this->_project   = (int) $project;


### PR DESCRIPTION
Hello,

I had the opportunity to test your module and I would say that you've done a great job here. It's working pretty good for me, except for one little thing.
Indeed, it seems that the endpoint that is used is somehow incorrect because of a missing `project_id` in the route. As the matter of fact, I found in [this](https://develop.sentry.dev/sdk/store/) website that the route for the "store" endpoint should be something like this : `/api/<project_id>/store/`
(According to the same website, it also seems that this endpoint is deprecated but that's another story)

I don't know if the route changed since you've released the latest version of your module, but with this little fix I managed to get things working correctly for me.
I hope this will help.